### PR TITLE
Fix tests

### DIFF
--- a/test/test.bats
+++ b/test/test.bats
@@ -1,30 +1,30 @@
 #!/usr/bin/env bats
 
-# Helper functions
-function query_shlack() {
-  ./shlack.sh --debug "$@"
-}
+##
+## Helper functions
+##
 
 function get_payload_item() {
-  echo "$2" | grep -oP "(?<=\"$1\": \").*?(?=\"(?:,|\}))"
+  echo "$2" | grep -Ev '^Slack hook URL' | sed "s/.*\"$1\": \"//;s/\",.*//;s/\"\}//"
 }
+
 
 ##
 ## Basic tests
 ##
 
 @test "exit correctly after sending a message" {
-  run query_shlack --text="test" --hook="http://hooks.slack.com/services/almost/legit/hook"
+  run ./shlack.sh --debug --text="test" --hook="http://hooks.slack.com/services/almost/legit/hook"
   [ "$status" -eq 0 ]
 }
 
 @test "fail without a hook URL" {
-  run query_shlack --hook=""
+  run ./shlack.sh --debug --hook="" --text="test"
   [ "$status" -eq 1 ]
 }
 
 @test "fail without a defined message" {
-  run query_shlack
+  run ./shlack.sh --debug --hook="foo"
   [ "$status" -eq 1 ]
 }
 
@@ -33,31 +33,31 @@ function get_payload_item() {
 ##
 
 @test "handle emoji surrounded by colons" {
-  result=$(query_shlack --text="test" --icon=":banana:")
+  result=$(./shlack.sh --debug --hook="foo" --text="test" --icon=":banana:")
   emoji=$(get_payload_item "icon_emoji" "$result")
   [ "$emoji" = ":banana:" ]
 }
 
 @test "handle emoji without colons" {
-  result=$(query_shlack --text="test" --icon="apple")
+  result=$(./shlack.sh --debug --hook="foo" --text="test" --icon="apple")
   emoji=$(get_payload_item "icon_emoji" "$result")
   [ "$emoji" = ":apple:" ]
 }
 
 @test "handle emoji with uneven colons" {
   # Missing on left
-  result=$(query_shlack --text="test" --icon="cherries:")
+  result=$(./shlack.sh --debug --hook="foo" --text="test" --icon="cherries:")
   emoji=$(get_payload_item "icon_emoji" "$result")
   [ "$emoji" = ":cherries:" ]
   
   # Missing on right
-  result=$(query_shlack --text="test" --icon=":cherries")
+  result=$(./shlack.sh --debug --hook="foo" --text="test" --icon=":cherries")
   emoji=$(get_payload_item "icon_emoji" "$result")
   [ "$emoji" = ":cherries:" ]
 }
 
 @test "support emojis with skin tone" {
-  result=$(query_shlack --text="test" --icon=":wave::skin-tone-3:")
+  result=$(./shlack.sh --debug --hook="foo" --text="test" --icon=":wave::skin-tone-3:")
   emoji=$(get_payload_item "icon_emoji" "$result")
   [ "$emoji" = ":wave::skin-tone-3:" ]
 }


### PR DESCRIPTION
  * Replaces generic call to `shlack.sh` with individual ones to better control the options.
  * Replaces a beautiful regular expression with an inverse `grep` and an ugly tandem of `sed` replacements so the tests work on Travis
  * Fixes #1

Notice: With the tests as they are, testing will fail locally if `.slack-hook` exists in the repository folder.